### PR TITLE
Update __init__.py

### DIFF
--- a/dblp/__init__.py
+++ b/dblp/__init__.py
@@ -18,7 +18,7 @@ class LazyAPIData(object):
             if self.data is None:
                 self.load_data()
             return self.data[key]
-        raise AttributeError, key
+        raise AttributeError(key)
 
     def load_data(self):
         pass


### PR DESCRIPTION
corrected a syntax error: "raise AttributeError(key)" instead of "raise AttributeError, key"